### PR TITLE
feat(middleware): Added X-Http-Method-Override header and associated …

### DIFF
--- a/src/main/scala/com/imageintelligence/http4c/headers/`Accept-Version`.scala
+++ b/src/main/scala/com/imageintelligence/http4c/headers/`Accept-Version`.scala
@@ -8,7 +8,6 @@ import org.http4s.util.CaseInsensitiveString
 import org.http4s.util.Writer
 import scala.util.Try
 
-
 final case class `Accept-Version`(version: String) extends Header.Parsed {
   override def key = `Accept-Version`
   override def renderValue(writer: Writer): writer.type =

--- a/src/main/scala/com/imageintelligence/http4c/headers/`X-Http-Method-Override`.scala
+++ b/src/main/scala/com/imageintelligence/http4c/headers/`X-Http-Method-Override`.scala
@@ -1,0 +1,28 @@
+package com.imageintelligence.http4c.headers
+
+import scalaz._, Scalaz._
+import org.http4s.HeaderKey
+import org.http4s.dsl._
+import org.http4s._
+import org.http4s.util.Writer
+import scala.util.Try
+
+final case class `X-Http-Method-Override`(method: String) extends Header.Parsed {
+  override def key = `X-Http-Method-Override`
+  override def renderValue(writer: Writer): writer.type =
+    writer.append(method)
+}
+
+object `X-Http-Method-Override` extends HeaderKey.Singleton {
+  type HeaderT = `X-Http-Method-Override`
+  def name = "X-HTTP-Method-Override".ci
+  def matchHeader(header: Header): Option[`X-Http-Method-Override`] = {
+    if (header.name == name)
+      Try(`X-Http-Method-Override`(header.value)).toOption
+    else None
+  }
+
+  def parse(s: String): ParseResult[`X-Http-Method-Override`] = {
+    `X-Http-Method-Override`(s).right
+  }
+}

--- a/src/main/scala/com/imageintelligence/http4c/middleware/XHttpMethodOverrideMiddleware.scala
+++ b/src/main/scala/com/imageintelligence/http4c/middleware/XHttpMethodOverrideMiddleware.scala
@@ -1,0 +1,26 @@
+package com.imageintelligence.http4c.middleware
+
+import org.http4s._
+import com.imageintelligence.http4c.headers.`X-Http-Method-Override`
+import scalaz.concurrent.Task
+import scalaz.{\/-, -\/}
+
+object XHttpMethodOverrideMiddleware {
+  def defaultFailureResponse: Task[Response] =
+    Response(Status.BadRequest).withBody(s"Invalid HTTP method provided in ${`X-Http-Method-Override`.name} header")
+
+  def apply(service: HttpService, failureResponseO: Option[Response] = None): HttpService = Service.lift { req =>
+    req.headers.get(`X-Http-Method-Override`) match {
+      case Some(method) => Method.fromString(method.method) match {
+        case -\/(failure) => failureResponseO.fold(defaultFailureResponse)(response => Task(response))
+        case \/-(success) => {
+          Method.registered.exists(_ == success) match {
+            case false => failureResponseO.fold(defaultFailureResponse)(response => Task(response))
+            case true  => service(req.copy(method = success))
+          }
+        }
+      }
+      case None => service(req)
+    }
+  }
+}


### PR DESCRIPTION
Added X-Http-Method-Override and associated middleware. The intent here to allow clients to issue requests with an alternate HTTP method in cases where the desired method is not available (e.g. due to proxies). For example, issuing a POST request with an X-HTTP-Method-Override value of PUT will internally rewrite the request method to PUT and allow http4s to route to the correct handler.

More information: https://webcache.googleusercontent.com/search?q=cache:Xay3_FDa55oJ:www.hanselman.com/blog/HTTPPUTOrDELETENotAllowedUseXHTTPMethodOverrideForYourRESTServiceWithASPNETWebAPI.aspx+&cd=1&hl=en&ct=clnk&gl=au